### PR TITLE
Add more tests for DeadlineCommand

### DIFF
--- a/data/record.txt
+++ b/data/record.txt
@@ -11,3 +11,4 @@ T | 0 | hello dad
 T | 0 | hello mum
 T | 0 | helllo
 T | 0 | hasd
+T | 0 | hello

--- a/src/test/java/eureka/command/DeadlineCommandTest.java
+++ b/src/test/java/eureka/command/DeadlineCommandTest.java
@@ -1,15 +1,38 @@
 package eureka.command;
 
+import eureka.Parser;
 import org.junit.jupiter.api.Test;
 
-import eureka.Parser;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DeadlineCommandTest {
 
     @Test
     public void testExit() {
         assertFalse(Parser.parse("deadline Test /by 2025-09-01 18:00").isExit());
+    }
+
+    @Test
+    public void parse_validDeadline_returnsDeadlineCommand() {
+        var cmd = Parser.parse("deadline Finish report /by 2025-09-01 18:00");
+        assertInstanceOf(DeadlineCommand.class, cmd);
+    }
+
+    @Test
+    public void parse_validDeadline_setsFieldsCorrectly() throws Exception {
+        var cmd = Parser.parse("deadline Finish report /by 2025-09-01 18:00");
+        assertInstanceOf(DeadlineCommand.class, cmd);
+
+        // reflectively verify private fields
+        Field taskNameF = DeadlineCommand.class.getDeclaredField("taskName");
+        taskNameF.setAccessible(true);
+        Field byF = DeadlineCommand.class.getDeclaredField("by");
+        byF.setAccessible(true);
+
+        assertEquals("Finish report", taskNameF.get(cmd));
+        assertEquals(LocalDateTime.of(2025, 9, 1, 18, 0), byF.get(cmd));
     }
 }


### PR DESCRIPTION
## 📝 Summary
Add additional unit tests for `DeadlineCommand` to improve coverage and error handling.

---

## ✅ Changes
- Added tests for:
  - Parsing valid deadline commands
- Verified internal fields (`taskName`, `by`) via reflection

Run with:
```bash
./gradlew test
